### PR TITLE
Add support for prose-val elements.

### DIFF
--- a/Sources/ABNFLib/ABNF+Parsing.swift
+++ b/Sources/ABNFLib/ABNF+Parsing.swift
@@ -277,6 +277,8 @@ extension ABNF {
             return charVal
         } else if let numVal = try? parseNumVal(from: input, options: options, cursor: &cursor) {
             return numVal
+        } else if let proseVal = try? parseProseVal(from: input, options: options, cursor: &cursor) {
+            return proseVal
         }
         throw ParserError(message: "Not a valid ABNF element")
     }
@@ -489,7 +491,19 @@ extension ABNF {
         }
         return try parseCRLF(from: input, options: options, cursor: internalCursor)
     }
+
+    private static func parseProseVal(from input: any StringProtocol, options: ParsingOptions, cursor: inout String.Index) throws -> Element {
+        guard input[cursor...].hasPrefix("<"),
+              let closing = input[cursor...].firstIndex(of: ">") else {
+            throw ParserError(message: "Not a valid prose value")
+        }
+        
+        let content = input[ input.index(after: cursor)..<closing]
+        cursor = input.index(after: closing)
+        return .proseVal(String(content))
+    }
     
+
     private static let visibleCharacterSets: [Encoding: CharacterSet] = Encoding.allCases.reduce(into: [:]) { dict, encoding in
         dict[encoding] = {
             switch encoding {

--- a/Sources/ABNFLib/ABNF+Validation.swift
+++ b/Sources/ABNFLib/ABNF+Validation.swift
@@ -520,6 +520,10 @@ extension ABNF {
                         matchedText: ""
                     )]
                 }
+            case .proseVal(_):
+                let error = ValidationError(index: position, message: "Prose-val cannot be validated")
+                errors.append(error)
+                throw error
             }
         }
         

--- a/Sources/ABNFLib/ABNF.swift
+++ b/Sources/ABNFLib/ABNF.swift
@@ -169,6 +169,14 @@ public indirect enum Element: Equatable, Hashable, Sendable {
     ///   - max: Maximum acceptable value (inclusive).
     ///   - type: The numeric base for the range.
     case numericRange(min: UInt32, max: UInt32, type: NumericType)
+    
+    /// A prosaic description of an element. Used as a last resort in grammars
+    /// where something can not be specified in ABNF.
+    ///
+    /// Corresponds to ABNF prose-val notation like `< *(not >) >`.
+    /// - Parameters:
+    ///   - String: The contents of the angle brackets.
+    case proseVal(String)
 }
 
 extension Element {

--- a/Tests/ABNFLibTests/ABNFLibTests.swift
+++ b/Tests/ABNFLibTests/ABNFLibTests.swift
@@ -211,6 +211,16 @@ import Testing
     #expect(throws: ABNF.ValidationError.self) { try abnf.validate(string: "    ") }
 }
 
+@Test func parseProseRule() async throws {
+    let rules = [
+        Rule(name: "literal", element: .proseVal("string256"))
+    ]
+    let abnf = try ABNF(string: "literal = <string256>")
+    #expect(abnf.rules == rules)
+    #expect(throws: ABNF.ValidationError.self) { try abnf.validate(string: " 01234567890123456789012345678901") }
+}
+
+
 @Test func parseStringCaseInsensitiveRule() async throws {
     let rules = [
         Rule(name: "hello", element: .string("hello"))


### PR DESCRIPTION
This adds an element and parsing support for the prose-val element.

It always makes an error in Validation for lack of a better idea, but it keeps the data in the parsed ABNF for other tools to use.